### PR TITLE
Revamp info API 86epb9dfc

### DIFF
--- a/drizzle/0001_robust_avengers.sql
+++ b/drizzle/0001_robust_avengers.sql
@@ -1,0 +1,112 @@
+ALTER TABLE "comments" DROP CONSTRAINT "comments_replied_info_id_infos_id_fk";
+--> statement-breakpoint
+ALTER TABLE "google_subscriptions" DROP CONSTRAINT "google_subscriptions_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "info_angkatan" DROP CONSTRAINT "info_angkatan_info_id_infos_id_fk";
+--> statement-breakpoint
+ALTER TABLE "info_categories" DROP CONSTRAINT "info_categories_info_id_infos_id_fk";
+--> statement-breakpoint
+ALTER TABLE "info_courses" DROP CONSTRAINT "info_courses_info_id_infos_id_fk";
+--> statement-breakpoint
+ALTER TABLE "info_medias" DROP CONSTRAINT "info_medias_info_id_infos_id_fk";
+--> statement-breakpoint
+ALTER TABLE "infos" DROP CONSTRAINT "infos_creator_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "medias" DROP CONSTRAINT "medias_creator_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "push_subscriptions" DROP CONSTRAINT "push_subscriptions_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "reactions" DROP CONSTRAINT "reactions_creator_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "user_courses" DROP CONSTRAINT "user_courses_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "user_read_infos" DROP CONSTRAINT "user_read_infos_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "user_unsubscribe_categories" DROP CONSTRAINT "user_unsubscribe_categories_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "users" DROP CONSTRAINT "users_angkatan_angkatan_year_fk";
+--> statement-breakpoint
+ALTER TABLE "info_courses" ALTER COLUMN "class" DROP NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "comments" ADD CONSTRAINT "comments_replied_info_id_infos_id_fk" FOREIGN KEY ("replied_info_id") REFERENCES "public"."infos"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "google_subscriptions" ADD CONSTRAINT "google_subscriptions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "info_angkatan" ADD CONSTRAINT "info_angkatan_info_id_infos_id_fk" FOREIGN KEY ("info_id") REFERENCES "public"."infos"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "info_categories" ADD CONSTRAINT "info_categories_info_id_infos_id_fk" FOREIGN KEY ("info_id") REFERENCES "public"."infos"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "info_courses" ADD CONSTRAINT "info_courses_info_id_infos_id_fk" FOREIGN KEY ("info_id") REFERENCES "public"."infos"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "info_medias" ADD CONSTRAINT "info_medias_info_id_infos_id_fk" FOREIGN KEY ("info_id") REFERENCES "public"."infos"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "infos" ADD CONSTRAINT "infos_creator_id_users_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "medias" ADD CONSTRAINT "medias_creator_id_users_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "push_subscriptions" ADD CONSTRAINT "push_subscriptions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "reactions" ADD CONSTRAINT "reactions_creator_id_users_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_courses" ADD CONSTRAINT "user_courses_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_read_infos" ADD CONSTRAINT "user_read_infos_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "user_unsubscribe_categories" ADD CONSTRAINT "user_unsubscribe_categories_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "users" ADD CONSTRAINT "users_angkatan_angkatan_year_fk" FOREIGN KEY ("angkatan") REFERENCES "public"."angkatan"("year") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1144 @@
+{
+  "id": "56899200-d66d-4cfd-bdd5-e9eac92d5f3c",
+  "prevId": "d9b85257-a343-4981-a1aa-7154c4822e27",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.angkatan": {
+      "name": "angkatan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "angkatan_year_unique": {
+          "name": "angkatan_year_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year"
+          ]
+        },
+        "angkatan_name_unique": {
+          "name": "angkatan_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_push": {
+          "name": "required_push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "replied_info_id": {
+          "name": "replied_info_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_replied_info_id_index": {
+          "name": "comments_replied_info_id_index",
+          "columns": [
+            "replied_info_id"
+          ],
+          "isUnique": false
+        },
+        "comments_creator_id_index": {
+          "name": "comments_creator_id_index",
+          "columns": [
+            "creator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_replied_info_id_infos_id_fk": {
+          "name": "comments_replied_info_id_infos_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "infos",
+          "columnsFrom": [
+            "replied_info_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_creator_id_users_id_fk": {
+          "name": "comments_creator_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "curriculum_year": {
+          "name": "curriculum_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurusan": {
+          "name": "jurusan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semester": {
+          "name": "semester",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semester_code": {
+          "name": "semester_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sks": {
+          "name": "sks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "courses_code_index": {
+          "name": "courses_code_index",
+          "columns": [
+            "code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "courses_code_unique": {
+          "name": "courses_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      }
+    },
+    "public.google_subscriptions": {
+      "name": "google_subscriptions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_in": {
+          "name": "expires_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "google_subscriptions_user_id_users_id_fk": {
+          "name": "google_subscriptions_user_id_users_id_fk",
+          "tableFrom": "google_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.info_angkatan": {
+      "name": "info_angkatan",
+      "schema": "",
+      "columns": {
+        "info_id": {
+          "name": "info_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angkatan_id": {
+          "name": "angkatan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "info_angkatan_info_id_infos_id_fk": {
+          "name": "info_angkatan_info_id_infos_id_fk",
+          "tableFrom": "info_angkatan",
+          "tableTo": "infos",
+          "columnsFrom": [
+            "info_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "info_angkatan_angkatan_id_angkatan_id_fk": {
+          "name": "info_angkatan_angkatan_id_angkatan_id_fk",
+          "tableFrom": "info_angkatan",
+          "tableTo": "angkatan",
+          "columnsFrom": [
+            "angkatan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "info_angkatan_info_id_angkatan_id_pk": {
+          "name": "info_angkatan_info_id_angkatan_id_pk",
+          "columns": [
+            "info_id",
+            "angkatan_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.info_categories": {
+      "name": "info_categories",
+      "schema": "",
+      "columns": {
+        "info_id": {
+          "name": "info_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "info_categories_info_id_infos_id_fk": {
+          "name": "info_categories_info_id_infos_id_fk",
+          "tableFrom": "info_categories",
+          "tableTo": "infos",
+          "columnsFrom": [
+            "info_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "info_categories_category_id_categories_id_fk": {
+          "name": "info_categories_category_id_categories_id_fk",
+          "tableFrom": "info_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "info_categories_info_id_category_id_pk": {
+          "name": "info_categories_info_id_category_id_pk",
+          "columns": [
+            "info_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.info_courses": {
+      "name": "info_courses",
+      "schema": "",
+      "columns": {
+        "info_id": {
+          "name": "info_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "info_courses_info_id_infos_id_fk": {
+          "name": "info_courses_info_id_infos_id_fk",
+          "tableFrom": "info_courses",
+          "tableTo": "infos",
+          "columnsFrom": [
+            "info_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "info_courses_course_id_courses_id_fk": {
+          "name": "info_courses_course_id_courses_id_fk",
+          "tableFrom": "info_courses",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "info_courses_info_id_course_id_pk": {
+          "name": "info_courses_info_id_course_id_pk",
+          "columns": [
+            "info_id",
+            "course_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.info_medias": {
+      "name": "info_medias",
+      "schema": "",
+      "columns": {
+        "info_id": {
+          "name": "info_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "info_medias_info_id_infos_id_fk": {
+          "name": "info_medias_info_id_infos_id_fk",
+          "tableFrom": "info_medias",
+          "tableTo": "infos",
+          "columnsFrom": [
+            "info_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "info_medias_media_id_medias_id_fk": {
+          "name": "info_medias_media_id_medias_id_fk",
+          "tableFrom": "info_medias",
+          "tableTo": "medias",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "info_medias_info_id_media_id_pk": {
+          "name": "info_medias_info_id_media_id_pk",
+          "columns": [
+            "info_id",
+            "media_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.infos": {
+      "name": "infos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "infos_creator_id_users_id_fk": {
+          "name": "infos_creator_id_users_id_fk",
+          "tableFrom": "infos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.medias": {
+      "name": "medias",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medias_creator_id_users_id_fk": {
+          "name": "medias_creator_id_users_id_fk",
+          "tableFrom": "medias",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "medias_name_unique": {
+          "name": "medias_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keys": {
+          "name": "keys",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_index": {
+          "name": "push_subscriptions_user_id_index",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "info_id": {
+          "name": "info_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reactions_info_id_index": {
+          "name": "reactions_info_id_index",
+          "columns": [
+            "info_id"
+          ],
+          "isUnique": false
+        },
+        "reactions_comment_id_index": {
+          "name": "reactions_comment_id_index",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reactions_creator_id_users_id_fk": {
+          "name": "reactions_creator_id_users_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_info_id_infos_id_fk": {
+          "name": "reactions_info_id_infos_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "infos",
+          "columnsFrom": [
+            "info_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_comment_id_comments_id_fk": {
+          "name": "reactions_comment_id_comments_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_creator_id_info_id_comment_id_unique": {
+          "name": "reactions_creator_id_info_id_comment_id_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "creator_id",
+            "info_id",
+            "comment_id"
+          ]
+        }
+      }
+    },
+    "public.user_courses": {
+      "name": "user_courses",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semester_code_taken": {
+          "name": "semester_code_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semester_year_taken": {
+          "name": "semester_year_taken",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_courses_user_id_users_id_fk": {
+          "name": "user_courses_user_id_users_id_fk",
+          "tableFrom": "user_courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_courses_course_id_courses_id_fk": {
+          "name": "user_courses_course_id_courses_id_fk",
+          "tableFrom": "user_courses",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_courses_user_id_course_id_pk": {
+          "name": "user_courses_user_id_course_id_pk",
+          "columns": [
+            "user_id",
+            "course_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.user_read_infos": {
+      "name": "user_read_infos",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "info_id": {
+          "name": "info_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_read_infos_user_id_users_id_fk": {
+          "name": "user_read_infos_user_id_users_id_fk",
+          "tableFrom": "user_read_infos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_read_infos_info_id_infos_id_fk": {
+          "name": "user_read_infos_info_id_infos_id_fk",
+          "tableFrom": "user_read_infos",
+          "tableTo": "infos",
+          "columnsFrom": [
+            "info_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_read_infos_user_id_info_id_pk": {
+          "name": "user_read_infos_user_id_info_id_pk",
+          "columns": [
+            "user_id",
+            "info_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.user_unsubscribe_categories": {
+      "name": "user_unsubscribe_categories",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_unsubscribe_categories_user_id_users_id_fk": {
+          "name": "user_unsubscribe_categories_user_id_users_id_fk",
+          "tableFrom": "user_unsubscribe_categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_unsubscribe_categories_category_id_categories_id_fk": {
+          "name": "user_unsubscribe_categories_category_id_categories_id_fk",
+          "tableFrom": "user_unsubscribe_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_unsubscribe_categories_user_id_category_id_pk": {
+          "name": "user_unsubscribe_categories_user_id_category_id_pk",
+          "columns": [
+            "user_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nim": {
+          "name": "nim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurusan": {
+          "name": "jurusan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asal_kampus": {
+          "name": "asal_kampus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angkatan": {
+          "name": "angkatan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jenis_kelamin": {
+          "name": "jenis_kelamin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_keanggotaan": {
+          "name": "status_keanggotaan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_nim_index": {
+          "name": "users_nim_index",
+          "columns": [
+            "nim"
+          ],
+          "isUnique": false
+        },
+        "users_email_index": {
+          "name": "users_email_index",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "users_angkatan_angkatan_year_fk": {
+          "name": "users_angkatan_angkatan_year_fk",
+          "tableFrom": "users",
+          "tableTo": "angkatan",
+          "columnsFrom": [
+            "angkatan"
+          ],
+          "columnsTo": [
+            "year"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_nim_unique": {
+          "name": "users_nim_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nim"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1715755342617,
       "tag": "0000_round_squadron_sinister",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1715786516495,
+      "tag": "0001_robust_avengers",
+      "breakpoints": true
     }
   ]
 }

--- a/src/controllers/info.controller.ts
+++ b/src/controllers/info.controller.ts
@@ -3,7 +3,7 @@ import { db } from '~/db/drizzle';
 import {
   createInfo,
   createReadInfo,
-  getListInfos,
+  // getListInfos,
 } from '~/repositories/info.repo';
 import { createInfoRoute, postReadInfoRoute } from '~/routes/info.route';
 import { InfoSchema } from '~/types/info.types';
@@ -32,12 +32,20 @@ infoRouter.openapi(postReadInfoRoute, async (c) => {
 });
 
 infoRouter.openapi(createInfoRoute, async (c) => {
-  const { mediaUrls, ...data } = c.req.valid('json');
+  const { mediaUrls, forAngkatan, forCategories, forCourses, ...data } =
+    c.req.valid('json');
   const { id } = c.var.user;
 
   try {
     const info = InfoSchema.parse(
-      await createInfo(db, { ...data, creatorId: id }, mediaUrls),
+      await createInfo(
+        db,
+        { ...data, creatorId: id },
+        mediaUrls,
+        forAngkatan,
+        forCategories,
+        forCourses,
+      ),
     );
     return c.json(info, 201);
   } catch (err) {
@@ -48,12 +56,12 @@ infoRouter.openapi(createInfoRoute, async (c) => {
   }
 });
 
-infoRouter.openapi(listInfoRoute, async (c) => {
-  const infos = await getListInfos(db, c.req.valid('query'), c.var.user.id);
-  return c.json(
-    {
-      infos,
-    },
-    200,
-  );
-});
+// infoRouter.openapi(listInfoRoute, async (c) => {
+//   const infos = await getListInfos(db, c.req.valid('query'), c.var.user.id);
+//   return c.json(
+//     {
+//       infos,
+//     },
+//     200,
+//   );
+// });

--- a/src/controllers/info.controller.ts
+++ b/src/controllers/info.controller.ts
@@ -4,7 +4,7 @@ import {
   createInfo,
   createReadInfo,
   deleteInfo,
-  // getListInfos,
+  getListInfos,
 } from '~/repositories/info.repo';
 import {
   createInfoRoute,
@@ -74,12 +74,12 @@ infoRouter.openapi(deleteInfoRoute, async (c) => {
   }
 });
 
-// infoRouter.openapi(listInfoRoute, async (c) => {
-//   const infos = await getListInfos(db, c.req.valid('query'), c.var.user.id);
-//   return c.json(
-//     {
-//       infos,
-//     },
-//     200,
-//   );
-// });
+infoRouter.openapi(listInfoRoute, async (c) => {
+  const infos = await getListInfos(db, c.req.valid('query'), c.var.user.id);
+  return c.json(
+    {
+      infos,
+    },
+    200,
+  );
+});

--- a/src/controllers/info.controller.ts
+++ b/src/controllers/info.controller.ts
@@ -3,9 +3,14 @@ import { db } from '~/db/drizzle';
 import {
   createInfo,
   createReadInfo,
+  deleteInfo,
   // getListInfos,
 } from '~/repositories/info.repo';
-import { createInfoRoute, postReadInfoRoute } from '~/routes/info.route';
+import {
+  createInfoRoute,
+  deleteInfoRoute,
+  postReadInfoRoute,
+} from '~/routes/info.route';
 import { InfoSchema } from '~/types/info.types';
 import { listInfoRoute } from '../routes/info.route';
 import { createAuthRouter } from './router-factory';
@@ -53,6 +58,19 @@ infoRouter.openapi(createInfoRoute, async (c) => {
       return c.json({ error: err.message }, 400);
     console.log(err);
     return c.json({ error: 'Something went wrong' }, 400);
+  }
+});
+
+infoRouter.openapi(deleteInfoRoute, async (c) => {
+  try {
+    const { infoId } = c.req.valid('param');
+    const info = await deleteInfo(db, infoId);
+    if (!info) {
+      return c.json({ error: 'Info not found' }, 404);
+    }
+    return c.json({}, 200);
+  } catch (err) {
+    return c.json(err, 500);
   }
 });
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -25,7 +25,7 @@ export const users = pgTable(
       enum: ['Ganesha', 'Jatinangor'],
     }).notNull(),
     angkatan: integer('angkatan')
-      .references(() => angkatan.year)
+      .references(() => angkatan.year, { onDelete: 'cascade' })
       .notNull(),
     gender: text('jenis_kelamin', { enum: ['F', 'M'] }).notNull(),
     membershipStatus: text('status_keanggotaan').notNull(),
@@ -60,7 +60,9 @@ export const pushSubscriptions = pgTable(
   'push_subscriptions',
   {
     endpoint: text('endpoint').primaryKey(),
-    userId: text('user_id').references(() => users.id),
+    userId: text('user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
     keys: json('keys').$type<webpush.PushSubscription['keys']>().notNull(),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
@@ -85,7 +87,7 @@ export const pushSubscriptionsRelation = relations(
 
 export const googleSubscriptions = pgTable('google_subscriptions', {
   userId: text('user_id')
-    .references(() => users.id)
+    .references(() => users.id, { onDelete: 'cascade' })
     .primaryKey(),
   idToken: text('id_token').notNull(),
   refreshToken: text('refresh_token').notNull(),
@@ -111,7 +113,7 @@ export const googleSubscriptionsRelation = relations(
 export const infos = pgTable('infos', {
   id: text('id').primaryKey().$defaultFn(createId),
   creatorId: text('creator_id')
-    .references(() => users.id)
+    .references(() => users.id, { onDelete: 'cascade' })
     .notNull(),
   content: text('content').notNull(),
   createdAt: timestamp('created_at', { withTimezone: true })
@@ -138,7 +140,7 @@ export const infosRelation = relations(infos, ({ one, many }) => ({
 export const medias = pgTable('medias', {
   id: text('id').primaryKey().$defaultFn(createId),
   creatorId: text('creator_id')
-    .references(() => users.id)
+    .references(() => users.id, { onDelete: 'cascade' })
     .notNull(),
   name: text('name').unique().notNull(),
   type: text('type').notNull(),
@@ -162,10 +164,10 @@ export const userReadInfos = pgTable(
   'user_read_infos',
   {
     userId: text('user_id')
-      .references(() => users.id)
+      .references(() => users.id, { onDelete: 'cascade' })
       .notNull(),
     infoId: text('info_id')
-      .references(() => infos.id)
+      .references(() => infos.id, { onDelete: 'cascade' })
       .notNull(),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
@@ -191,10 +193,10 @@ export const infoMedias = pgTable(
   'info_medias',
   {
     infoId: text('info_id')
-      .references(() => infos.id)
+      .references(() => infos.id, { onDelete: 'cascade' })
       .notNull(),
     mediaId: text('media_id')
-      .references(() => medias.id)
+      .references(() => medias.id, { onDelete: 'cascade' })
       .notNull(),
   },
   (t) => ({ pk: primaryKey({ columns: [t.infoId, t.mediaId] }) }),
@@ -216,10 +218,10 @@ export const comments = pgTable(
   {
     id: text('id').primaryKey().$defaultFn(createId),
     repliedInfoId: text('replied_info_id')
-      .references(() => infos.id)
+      .references(() => infos.id, { onDelete: 'cascade' })
       .notNull(),
     creatorId: text('creator_id')
-      .references(() => users.id)
+      .references(() => users.id, { onDelete: 'cascade' })
       .notNull(),
     content: text('content').notNull(),
     createdAt: timestamp('created_at', { withTimezone: true })
@@ -251,10 +253,12 @@ export const reactions = pgTable(
   {
     id: text('id').primaryKey().$defaultFn(createId),
     creatorId: text('creator_id')
-      .references(() => users.id)
+      .references(() => users.id, { onDelete: 'cascade' })
       .notNull(),
-    infoId: text('info_id').references(() => infos.id),
-    commentId: text('comment_id').references(() => comments.id),
+    infoId: text('info_id').references(() => infos.id, { onDelete: 'cascade' }),
+    commentId: text('comment_id').references(() => comments.id, {
+      onDelete: 'cascade',
+    }),
     reaction: text('reaction').notNull(),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
@@ -342,12 +346,12 @@ export const infoCourses = pgTable(
   'info_courses',
   {
     infoId: text('info_id')
-      .references(() => infos.id)
+      .references(() => infos.id, { onDelete: 'cascade' })
       .notNull(),
     courseId: text('course_id')
-      .references(() => courses.id)
+      .references(() => courses.id, { onDelete: 'cascade' })
       .notNull(),
-    class: integer('class').notNull(),
+    class: integer('class'),
   },
   (t) => ({ pk: primaryKey({ columns: [t.infoId, t.courseId] }) }),
 );
@@ -364,10 +368,10 @@ export const infoAngkatan = pgTable(
   'info_angkatan',
   {
     infoId: text('info_id')
-      .references(() => infos.id)
+      .references(() => infos.id, { onDelete: 'cascade' })
       .notNull(),
     angkatanId: text('angkatan_id')
-      .references(() => angkatan.id)
+      .references(() => angkatan.id, { onDelete: 'cascade' })
       .notNull(),
   },
   (t) => ({ pk: primaryKey({ columns: [t.infoId, t.angkatanId] }) }),
@@ -385,10 +389,10 @@ export const infoCategories = pgTable(
   'info_categories',
   {
     infoId: text('info_id')
-      .references(() => infos.id)
+      .references(() => infos.id, { onDelete: 'cascade' })
       .notNull(),
     categoryId: text('category_id')
-      .references(() => categories.id)
+      .references(() => categories.id, { onDelete: 'cascade' })
       .notNull(),
   },
   (t) => ({ pk: primaryKey({ columns: [t.infoId, t.categoryId] }) }),
@@ -408,8 +412,10 @@ export const infoCategoriesRelation = relations(infoCategories, ({ one }) => ({
 export const userCourses = pgTable(
   'user_courses',
   {
-    userId: text('user_id').references(() => users.id),
-    courseId: text('course_id').references(() => courses.id),
+    userId: text('user_id').references(() => users.id, { onDelete: 'cascade' }),
+    courseId: text('course_id').references(() => courses.id, {
+      onDelete: 'cascade',
+    }),
     class: integer('class').notNull(),
     semesterCodeTaken: text('semester_code_taken', {
       enum: ['Ganjil', 'Genap'],
@@ -431,10 +437,10 @@ export const userUnsubscribeCategories = pgTable(
   'user_unsubscribe_categories',
   {
     userId: text('user_id')
-      .references(() => users.id)
+      .references(() => users.id, { onDelete: 'cascade' })
       .notNull(),
     categoryId: text('category_id')
-      .references(() => categories.id)
+      .references(() => categories.id, { onDelete: 'cascade' })
       .notNull(),
   },
   (t) => ({ pk: primaryKey({ columns: [t.userId, t.categoryId] }) }),

--- a/src/repositories/info.repo.ts
+++ b/src/repositories/info.repo.ts
@@ -1,10 +1,17 @@
 import { InferInsertModel, SQL, and, eq, ilike, notInArray } from 'drizzle-orm';
 import { z } from 'zod';
-import { Database } from '~/db/drizzle';
-import { firstSure } from '~/db/helper';
-import { infos, userReadInfos } from '~/db/schema';
-import { ListInfoParamsSchema } from '~/types/info.types';
-import { createInfoMedia, createMediasFromUrl } from './media.repo';
+import { Database, db } from '~/db/drizzle';
+import { first, firstSure } from '~/db/helper';
+import {
+  infoAngkatan,
+  infoCategories,
+  infoCourses,
+  infoMedias,
+  infos,
+  userReadInfos,
+} from '~/db/schema';
+import { CreateInfoBodySchema, ListInfoParamsSchema } from '~/types/info.types';
+import { createMediasFromUrl } from './media.repo';
 
 const INFOS_PER_PAGE = 10;
 
@@ -14,7 +21,10 @@ const INFOS_PER_PAGE = 10;
 export async function createInfo(
   db: Database,
   data: Omit<InferInsertModel<typeof infos>, 'createdAt'>,
-  mediaUrls: string[] | undefined,
+  mediaUrls: z.infer<typeof CreateInfoBodySchema.shape.mediaUrls>,
+  forAngkatan: z.infer<typeof CreateInfoBodySchema.shape.forAngkatan>,
+  forCategories: z.infer<typeof CreateInfoBodySchema.shape.forCategories>,
+  forCourses: z.infer<typeof CreateInfoBodySchema.shape.forCourses>,
 ) {
   // transaction drizzle auto rollback kalo error
   return await db.transaction(async (tx) => {
@@ -24,6 +34,16 @@ export async function createInfo(
       .returning()
       .then(firstSure);
 
+    // Attach categories to the info with InfoCategory
+    await createInfoCategory(
+      tx,
+      forCategories.map((categoryId) => ({
+        infoId: newInfo.id,
+        categoryId,
+      })),
+    );
+
+    // If mediaUrls is supplied, then create those Media and attach them to the info with InfoMedia
     if (mediaUrls) {
       const newMedias = await createMediasFromUrl(
         tx,
@@ -39,9 +59,65 @@ export async function createInfo(
         })),
       );
     }
+
+    // If forAngkatan is supplied, then attach angkatan to the info with InfoAngkatan
+    if (forAngkatan) {
+      await createInfoAngkatan(
+        tx,
+        forAngkatan.map((angkatanId) => ({
+          infoId: newInfo.id,
+          angkatanId,
+        })),
+      );
+    }
+
+    // If forCourses is supplied, then attach courses to the info with InfoCourses
+    if (forCourses) {
+      await createInfoCourses(
+        tx,
+        forCourses.map((course) => ({
+          infoId: newInfo.id,
+          courseId: course.courseId,
+          class: course.class,
+        })),
+      );
+    }
+
     return newInfo;
   });
 }
+
+export const createInfoCategory = async (
+  db: Database,
+  data: Array<InferInsertModel<typeof infoCategories>>,
+) => {
+  return await db
+    .insert(infoCategories)
+    .values(data)
+    .returning()
+    .then(firstSure);
+};
+
+export const createInfoMedia = async (
+  db: Database,
+  data: Array<Omit<InferInsertModel<typeof infoMedias>, 'createdAt'>>,
+) => {
+  return await db.insert(infoMedias).values(data).returning().then(firstSure);
+};
+
+export const createInfoAngkatan = async (
+  db: Database,
+  data: Array<InferInsertModel<typeof infoAngkatan>>,
+) => {
+  return await db.insert(infoAngkatan).values(data).returning().then(firstSure);
+};
+
+export const createInfoCourses = async (
+  db: Database,
+  data: Array<InferInsertModel<typeof infoCourses>>,
+) => {
+  return await db.insert(infoCourses).values(data).returning().then(firstSure);
+};
 
 export async function createReadInfo(
   db: Database,
@@ -54,35 +130,45 @@ export async function createReadInfo(
     .then(firstSure);
 }
 
-export async function getListInfos(
-  db: Database,
-  q: z.infer<typeof ListInfoParamsSchema>,
-  userId: string,
-) {
-  const searchQ = q.search ? ilike(infos.content, `%${q.search}%`) : undefined;
-  const categoryQ = q.category ? eq(infos.category, q.category) : undefined;
-  let unreadQ: SQL<unknown> | undefined;
-
-  if (q.unread === 'true') {
-    const getReadInfosByUser = db
-      .select({ infoId: userReadInfos.infoId })
-      .from(userReadInfos)
-      .where(eq(userReadInfos.userId, userId));
-    unreadQ = notInArray(infos.id, getReadInfosByUser);
-  }
-
-  const where = and(searchQ, categoryQ, unreadQ);
-
-  return await db.query.infos.findMany({
-    where,
-    limit: INFOS_PER_PAGE,
-    offset: q.offset,
-    with: {
-      infoMedias: {
-        with: {
-          media: true,
-        },
-      },
-    },
-  });
+export async function deleteInfo(db: Database, id: string) {
+  const info = await db
+    .delete(infos)
+    .where(eq(infos.id, id))
+    .returning()
+    .then(first);
+  return info;
 }
+
+// TODO: Recreate this!!
+// export async function getListInfos(
+//   db: Database,
+//   q: z.infer<typeof ListInfoParamsSchema>,
+//   userId: string,
+// ) {
+//   const searchQ = q.search ? ilike(infos.content, `%${q.search}%`) : undefined;
+//   const categoryQ = q.category ? eq(infos.category, q.category) : undefined;
+//   let unreadQ: SQL<unknown> | undefined;
+
+//   if (q.unread === 'true') {
+//     const getReadInfosByUser = db
+//       .select({ infoId: userReadInfos.infoId })
+//       .from(userReadInfos)
+//       .where(eq(userReadInfos.userId, userId));
+//     unreadQ = notInArray(infos.id, getReadInfosByUser);
+//   }
+
+//   const where = and(searchQ, categoryQ, unreadQ);
+
+//   return await db.query.infos.findMany({
+//     where,
+//     limit: INFOS_PER_PAGE,
+//     offset: q.offset,
+//     with: {
+//       infoMedias: {
+//         with: {
+//           media: true,
+//         },
+//       },
+//     },
+//   });
+// }

--- a/src/repositories/media.repo.ts
+++ b/src/repositories/media.repo.ts
@@ -1,7 +1,5 @@
-import { InferInsertModel } from 'drizzle-orm';
 import { Database } from '~/db/drizzle';
-import { firstSure } from '~/db/helper';
-import { infoMedias, medias } from '~/db/schema';
+import { medias } from '~/db/schema';
 
 // EXAMPLE URL -> https://pub-45e54d5755814b02b87e024df83efb57.r2.dev/r176r3qcuqs3hg8o3dm93n35-asrielblunt.jpg
 export const createMediasFromUrl = async (
@@ -27,11 +25,4 @@ export const createMediasFromUrl = async (
       }),
     )
     .returning();
-};
-
-export const createInfoMedia = async (
-  db: Database,
-  data: Array<Omit<InferInsertModel<typeof infoMedias>, 'createdAt'>>,
-) => {
-  return await db.insert(infoMedias).values(data).returning().then(firstSure);
 };

--- a/src/repositories/reaction.repo.ts
+++ b/src/repositories/reaction.repo.ts
@@ -28,7 +28,7 @@ export async function getReactions(
     .from(reactions)
     .where(where)
     .groupBy(reactions.reaction);
-  if (!reactionCount.length) return null; // No reactions found
+  // if (!reactionCount.length) return null; // No reactions found
 
   let total = 0;
   const reactionsMap: z.infer<typeof ReactionCountSchema> = [];

--- a/src/routes/info.route.ts
+++ b/src/routes/info.route.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from '@hono/zod-openapi';
 import {
   CreateInfoBodySchema,
   CreateReadRequestBodySchema,
+  InfoIdParamsSchema,
   InfoSchema,
   ListInfoParamsSchema,
   ListInfoSchema,
@@ -83,6 +84,29 @@ export const listInfoRoute = createRoute({
         },
       },
       description: 'Get list of infos based on filter',
+    },
+    400: {
+      description: 'Bad request',
+      content: {
+        'application/json': {
+          schema: z.union([ErrorSchema, ValidationErrorSchema]),
+        },
+      },
+    },
+  },
+});
+
+export const deleteInfoRoute = createRoute({
+  operationId: 'deleteInfo',
+  tags: ['info'],
+  method: 'delete',
+  path: '/info/{infoId}',
+  request: {
+    params: InfoIdParamsSchema,
+  },
+  responses: {
+    200: {
+      description: 'Info deleted',
     },
     400: {
       description: 'Bad request',

--- a/src/routes/info.route.ts
+++ b/src/routes/info.route.ts
@@ -1,7 +1,7 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import {
+  CreateInfoBodySchema,
   CreateReadRequestBodySchema,
-  InfoParamSchema,
   InfoSchema,
   ListInfoParamsSchema,
   ListInfoSchema,
@@ -41,7 +41,7 @@ export const createInfoRoute = createRoute({
     body: {
       content: {
         'application/json': {
-          schema: InfoParamSchema,
+          schema: CreateInfoBodySchema,
         },
       },
       required: true,

--- a/src/routes/info.route.ts
+++ b/src/routes/info.route.ts
@@ -68,8 +68,8 @@ export const createInfoRoute = createRoute({
   },
 });
 
-export const listInfoRoute = createRoute({
-  operationId: 'getListInfos',
+export const getListInfoRoute = createRoute({
+  operationId: 'getListInfo',
   tags: ['info'],
   method: 'get',
   path: '/info',
@@ -96,6 +96,42 @@ export const listInfoRoute = createRoute({
   },
 });
 
+export const getInfoByIdRoute = createRoute({
+  operationId: 'getInfoById',
+  tags: ['info'],
+  method: 'get',
+  path: '/info/{infoId}',
+  request: {
+    params: InfoIdParamsSchema,
+  },
+  responses: {
+    200: {
+      description: 'Get info by id',
+      content: {
+        'application/json': {
+          schema: InfoSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Bad request',
+      content: {
+        'application/json': {
+          schema: z.union([ErrorSchema, ValidationErrorSchema]),
+        },
+      },
+    },
+    404: {
+      description: 'Id not found',
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+    },
+  },
+});
+
 export const deleteInfoRoute = createRoute({
   operationId: 'deleteInfo',
   tags: ['info'],
@@ -113,6 +149,14 @@ export const deleteInfoRoute = createRoute({
       content: {
         'application/json': {
           schema: z.union([ErrorSchema, ValidationErrorSchema]),
+        },
+      },
+    },
+    404: {
+      description: 'Id not found',
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
         },
       },
     },

--- a/src/types/angkatan.types.ts
+++ b/src/types/angkatan.types.ts
@@ -1,0 +1,4 @@
+import { createSelectSchema } from 'drizzle-zod';
+import { angkatan } from '~/db/schema';
+
+export const AngkatanSchema = createSelectSchema(angkatan);

--- a/src/types/category.types.ts
+++ b/src/types/category.types.ts
@@ -1,0 +1,4 @@
+import { createSelectSchema } from 'drizzle-zod';
+import { categories } from '~/db/schema';
+
+export const CategorySchema = createSelectSchema(categories);

--- a/src/types/info.types.ts
+++ b/src/types/info.types.ts
@@ -1,10 +1,45 @@
 import { z } from '@hono/zod-openapi';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
-import { infos } from '~/db/schema';
+import {
+  infoAngkatan,
+  infoCategories,
+  infoCourses,
+  infoMedias,
+  infos,
+} from '~/db/schema';
+import { CategorySchema } from './category.types';
+import { MediaSchema } from './media.types';
+import { AngkatanSchema } from './angkatan.types';
+import { CourseSchema } from './course.types';
+import { ReactionResponseSchema } from './reaction.types';
+
+export const InfoCategorySchema = createSelectSchema(infoCategories).extend({
+  category: CategorySchema,
+});
+
+export const InfoMediaSchema = createSelectSchema(infoMedias).extend({
+  media: MediaSchema,
+});
+
+export const InfoAngkatanSchema = createSelectSchema(infoAngkatan).extend({
+  angkatan: AngkatanSchema,
+});
+
+export const InfoCourseSchema = createSelectSchema(infoCourses).extend({
+  course: CourseSchema,
+});
 
 export const InfoSchema = createSelectSchema(infos, {
   createdAt: z.union([z.string(), z.date()]),
-}).openapi('Info');
+})
+  .extend({
+    infoMedias: z.array(InfoMediaSchema).optional(),
+    infoCategories: z.array(InfoCategorySchema).optional(),
+    infoCourses: z.array(InfoCourseSchema).optional(),
+    infoAngkatan: z.array(InfoAngkatanSchema).optional(),
+    reactions: ReactionResponseSchema.optional(),
+  })
+  .openapi('Info');
 
 export const CreateInfoForCoursesFieldItemSchema = z.object({
   courseId: z.string(),

--- a/src/types/info.types.ts
+++ b/src/types/info.types.ts
@@ -1,37 +1,56 @@
 import { z } from '@hono/zod-openapi';
-import { createSelectSchema } from 'drizzle-zod';
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { infos } from '~/db/schema';
-
-export const InfoParamSchema = z.object({
-  content: z.string().openapi({
-    example: 'Tutor Sebaya dengan Dr. Asep Spakbor',
-  }),
-  category: z.string().openapi({
-    example: 'Akademik',
-  }),
-  forAngkatan: z.number().int().openapi({
-    example: 2021,
-  }),
-  mediaUrls: z
-    .array(z.string().url())
-    .optional()
-    .openapi({
-      example: [
-        'https://pub-45e54d5755814b02b87e024df83efb57.r2.dev/r176r3qcuqs3hg8o3dm93n35-asrielblunt.jpg',
-        'https://pub-45e54d5755814b02b87e024df83efb57.r2.dev/ba245cbm4238trmq4zv5kkif-semester-cat.png',
-      ],
-    }),
-  forMatakuliah: z.string().openapi({
-    example: 'II2111 Algoritma dan Struktur Data STI',
-  }),
-  forClass: z.string().openapi({
-    example: 'K01',
-  }),
-});
 
 export const InfoSchema = createSelectSchema(infos, {
   createdAt: z.union([z.string(), z.date()]),
 }).openapi('Info');
+
+export const CreateInfoForCoursesFieldItemSchema = z.object({
+  courseId: z.string(),
+  class: z.number().optional(),
+});
+
+export const CreateInfoBodySchema = createInsertSchema(infos)
+  .omit({
+    id: true,
+    creatorId: true,
+    createdAt: true,
+  })
+  .extend({
+    mediaUrls: z
+      .array(z.string().url())
+      .optional()
+      .openapi({
+        example: [
+          'https://pub-45e54d5755814b02b87e024df83efb57.r2.dev/r176r3qcuqs3hg8o3dm93n35-asrielblunt.jpg',
+          'https://deleteMediaUrlsFieldIfNoMediaUrls.dev',
+        ],
+      }),
+    forCategories: z.array(z.string()).openapi({
+      example: ['categoryId1', 'categoryId2'],
+    }),
+    forAngkatan: z
+      .array(z.string())
+      .optional()
+      .openapi({
+        example: ['angkatanId1', 'deleteForAngkatanFieldIfWantToAllAngkatan'],
+      }),
+    forCourses: z
+      .array(CreateInfoForCoursesFieldItemSchema)
+      .optional()
+      .openapi({
+        example: [
+          {
+            courseId: 'deleteForCoursesFieldIfNoCourses',
+            class: 1,
+          },
+          {
+            courseId: 'deleteClassFieldIfWantToAllClass',
+          },
+        ],
+      }),
+  });
 
 export const CreateReadRequestBodySchema = z.object({
   infoId: z.string(),

--- a/src/types/info.types.ts
+++ b/src/types/info.types.ts
@@ -56,6 +56,16 @@ export const CreateReadRequestBodySchema = z.object({
   infoId: z.string(),
 });
 
+export const InfoIdParamsSchema = z.object({
+  infoId: z.string().openapi({
+    param: {
+      in: 'path',
+      description: 'Id of info',
+      example: 'uuid',
+    },
+  }),
+});
+
 export const ListInfoParamsSchema = z.object({
   search: z.string().optional().openapi({
     example: 'content',

--- a/src/types/media.types.ts
+++ b/src/types/media.types.ts
@@ -1,4 +1,10 @@
 import { z } from '@hono/zod-openapi';
+import { createSelectSchema } from 'drizzle-zod';
+import { medias } from '~/db/schema';
+
+export const MediaSchema = createSelectSchema(medias, {
+  createdAt: z.union([z.string(), z.date()]),
+});
 
 export const BodyParamsSchema = z.object({
   fileName: z.string().openapi({


### PR DESCRIPTION
- Change schema so that all foreign keys cascades on delete
- Create getInfoById and deleteInfo routes
- Change createInfo to accomodate new relations (course, angkatan, category)
- Return info schema now shows relation schemas
- Add reaction count to info when getting