### PR TITLE
Sorting on info API 86epktu7t

### DIFF
--- a/src/repositories/info.repo.ts
+++ b/src/repositories/info.repo.ts
@@ -215,6 +215,17 @@ export async function getListInfos(
     }),
   );
 
+  // Sort based on 'sort' query params
+  if (q.sort) {
+    listInfo = listInfo.sort((a, b) => {
+      if (q.sort === 'oldest') {
+        return a.createdAt.getTime() - b.createdAt.getTime();
+      } else {
+        return b.createdAt.getTime() - a.createdAt.getTime();
+      }
+    });
+  }
+
   return listInfo;
 }
 

--- a/src/types/info.types.ts
+++ b/src/types/info.types.ts
@@ -122,6 +122,9 @@ export const ListInfoParamsSchema = z.object({
   offset: z.coerce.number().int().nonnegative().optional().openapi({
     example: 10,
   }),
+  sort: z.enum(['oldest', 'newest']).default('newest').openapi({
+    example: 'newest',
+  }),
 });
 
 export const ListInfoSchema = z.object({


### PR DESCRIPTION
# Sorting in Infos GET API
## Addition
Added query parameter 'sort' in route GET /api/infos
> 'sort' values are enums: `['oldest', 'newest']`
> Default value of sort is `'newest'`
## Testing
### Initial Database Values
![image](https://github.com/hmif-itb/hmif-app-be/assets/110521599/b30a4987-dc3d-43ad-a5cf-c3a457267ca0)


### Sorting with query params `'sort' = 'newest'` or no query params
![image](https://github.com/hmif-itb/hmif-app-be/assets/110521599/b202bc53-3a7e-4330-b571-42d0aab0baeb)
![image](https://github.com/hmif-itb/hmif-app-be/assets/110521599/df021ec8-b0d1-4cce-9037-554b1e6dab28)

### Sorting with query params `'sort' = 'oldest'`
![image](https://github.com/hmif-itb/hmif-app-be/assets/110521599/c6548e84-d1ce-48b5-8826-87d726174a7a)

